### PR TITLE
feat: add default header sizes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
 
   theme:
     devDependencies:
+      '@chakra-ui/anatomy':
+        specifier: ^2.2.2
+        version: 2.2.2
       '@chakra-ui/react':
         specifier: ^2.8.2
         version: 2.8.2(@emotion/react@11.11.4)(@emotion/styled@11.11.0)(@types/react@18.2.64)(framer-motion@11.0.8)(react-dom@18.2.0)(react@18.2.0)

--- a/testing/src/views/Headings.tsx
+++ b/testing/src/views/Headings.tsx
@@ -6,7 +6,7 @@ export function Headings() {
   return (
     <>
       {headings.map(heading => (
-        <Heading as={heading} variant={heading}>
+        <Heading as={heading} key={`header_${heading}`} >
           {heading.toUpperCase()} (Heading {heading[1]})
         </Heading>
       ))}

--- a/theme/package.json
+++ b/theme/package.json
@@ -24,10 +24,12 @@
     "publish:dry": "pnpm publish --no-git-checks --dry-run"
   },
   "peerDependencies": {
+    "@chakra-ui/anatomy": "^2.2.2",
     "@chakra-ui/react": "^2.8.2",
     "@chakra-ui/theme-tools": "^2.1.2"
   },
   "devDependencies": {
+    "@chakra-ui/anatomy": "^2.2.2",
     "@chakra-ui/react": "^2.8.2",
     "@chakra-ui/theme-tools": "^2.1.2",
     "@types/node": "^20.11.26",

--- a/theme/src/components/headings.ts
+++ b/theme/src/components/headings.ts
@@ -8,7 +8,6 @@ const h1 = defineStyle({
   lineHeight: '2.25rem'
 })
 
-
 const h2 = defineStyle({
   fontFamily: "Raleway",
   fontSize: '1.5rem',
@@ -16,7 +15,6 @@ const h2 = defineStyle({
   fontWeight: '700',
   lineHeight: '2rem'
 })
-
 
 const h3 = defineStyle({
   fontFamily: "Raleway",
@@ -48,13 +46,29 @@ const variants = {
   h3,
   h4,
   h5
-}
+} as const
+
+type HeaderVariant = typeof variants
+
+const variantMap = new Map(Object.entries(variants))
+const DEFAULT_VARIANT = h1
 
 export const headingTheme = defineStyleConfig({
-  baseStyle: {
-  },
+  baseStyle: defineStyle((props) => {
+    let selectedVariant: HeaderVariant[keyof HeaderVariant] | undefined
+
+    if (props.variant && variantMap.has(props.variant)) {
+      selectedVariant = variantMap.get(props.variant)
+    }
+
+    if (!!props.as && variantMap.has(props.as)) {
+      selectedVariant = variantMap.get(props.as)
+    }
+
+    return selectedVariant || DEFAULT_VARIANT
+  }),
   variants,
   defaultProps: {
-    variant: "h1",
+    variant: undefined,
   }
 })


### PR DESCRIPTION
It is no longer required to define the `variant` for a header. It will be reflected based on the `as` property.

```tsx
// Before
<Header as="h1" variant="h1">...</Header>

// After - will have the same style
<Header as="h1">...</Header>

// You can still overwrite and keep the size
<Header as="h1" variant="h3">...</Header>
```