### PR TITLE
fix / CLOUD-25855 / exports

### DIFF
--- a/testing/src/App.tsx
+++ b/testing/src/App.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { Box, ChakraBaseProvider, Heading } from '@chakra-ui/react'
-import { theme } from '../../theme/src/main'
+import theme from '../../theme/src/main'
 
 import { Alerts } from '@/views/Alerts.tsx'
 import { Buttons } from '@/views/Buttons'

--- a/testing/src/main.tsx
+++ b/testing/src/main.tsx
@@ -19,7 +19,7 @@ import { ChakraProvider, ColorModeScript } from '@chakra-ui/react'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { bootstrap } from 'safetest/react'
-import { theme } from '../../theme/src/main'
+import theme from '../../theme/src/main'
 
 // biome-ignore lint/style/noNonNullAssertion: <explanation>
 const root = ReactDOM.createRoot(document.getElementById('root')!)

--- a/testing/src/views/Alerts.safetest.tsx
+++ b/testing/src/views/Alerts.safetest.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { ChakraBaseProvider } from '@chakra-ui/react'
-import { theme } from '@hivemq/ui-theme'
+import theme from '@hivemq/ui-theme'
 import { render } from 'safetest/react'
 import { describe, expect, it } from 'safetest/vitest'
 

--- a/testing/src/views/Buttons.safetest.tsx
+++ b/testing/src/views/Buttons.safetest.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { ChakraBaseProvider } from '@chakra-ui/react'
-import { theme } from '@hivemq/ui-theme'
+import theme from '@hivemq/ui-theme'
 import { render } from 'safetest/react'
 import { describe, expect, it } from 'safetest/vitest'
 

--- a/testing/src/views/Colors.safetest.tsx
+++ b/testing/src/views/Colors.safetest.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { ChakraBaseProvider } from '@chakra-ui/react'
-import { theme } from '@hivemq/ui-theme'
+import theme from '@hivemq/ui-theme'
 import { render } from 'safetest/react'
 import { describe, expect, it } from 'safetest/vitest'
 

--- a/testing/src/views/Headings.safetest.tsx
+++ b/testing/src/views/Headings.safetest.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { ChakraBaseProvider } from '@chakra-ui/react'
-import { theme } from '@hivemq/ui-theme'
+import theme from '@hivemq/ui-theme'
 import { render } from 'safetest/react'
 import { describe, expect, it } from 'safetest/vitest'
 

--- a/testing/src/views/Links.safetest.tsx
+++ b/testing/src/views/Links.safetest.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { ChakraBaseProvider } from '@chakra-ui/react'
-import { theme } from '@hivemq/ui-theme'
+import theme from '@hivemq/ui-theme'
 import { render } from 'safetest/react'
 import { describe, expect, it } from 'safetest/vitest'
 

--- a/testing/src/views/SemanticColors.safetest.tsx
+++ b/testing/src/views/SemanticColors.safetest.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { ChakraBaseProvider } from '@chakra-ui/react'
-import { theme } from '@hivemq/ui-theme'
+import theme from '@hivemq/ui-theme'
 import { render } from 'safetest/react'
 import { describe, expect, it } from 'safetest/vitest'
 

--- a/testing/src/views/Texts.safetest.tsx
+++ b/testing/src/views/Texts.safetest.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { ChakraBaseProvider } from '@chakra-ui/react'
-import { theme } from '@hivemq/ui-theme'
+import theme from '@hivemq/ui-theme'
 import { render } from 'safetest/react'
 import { describe, expect, it } from 'safetest/vitest'
 

--- a/theme/src/main.ts
+++ b/theme/src/main.ts
@@ -24,14 +24,14 @@ import { fontSizes, textTheme } from './components/text'
 import * as colors from './foundations/colors'
 import * as semanticColors from './style-guide/semanticColors'
 
-const fonts = {
+export const fonts = {
   heading: "'Raleway', 'Roboto', 'Segoe UI', 'sans-serif'",
   body: "'Roboto', 'Segoe UI', 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', 'Arial', 'sans-serif', 'system-ui', '-apple-system'",
   monospace:
     "'Roboto Mono', 'IntelOne Mono', 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', 'monospace'",
 }
 
-const styles = {
+export const styles = {
   global: (_props: StyleFunctionProps) => ({
     // override the default values with our semantic tokens
     body: {
@@ -48,7 +48,7 @@ const styles = {
   }),
 } as const
 
-const components = {
+export const components = {
   Alert: alertTheme,
   Button: buttonTheme,
   Heading: headingTheme,
@@ -56,7 +56,12 @@ const components = {
   Text: textTheme,
 } as const
 
-export const theme = extendBaseTheme({
+export { colors }
+export const semanticTokens = {
+  colors: semanticColors,
+}
+
+const theme = extendBaseTheme({
   config: {
     initialColorMode: 'light',
     useSystemColorMode: false,
@@ -67,8 +72,8 @@ export const theme = extendBaseTheme({
   colors: {
     ...colors,
   },
-  semanticTokens: {
-    colors: semanticColors,
-  },
+  semanticTokens,
   components,
 })
+
+export default theme


### PR DESCRIPTION
## Why

Exports were changed in v0.4.1 and it's breaking the build of other projects trying to import `components`, `colors`, `fonts` or `styles`.
e.g.
```ts
import { colors, components, styles, fonts } from '@hivemq/ui-theme'
```

## What

- export `theme` as default
- re-export `components`, `colors`, `fonts` and `styles`
- also export `semanticTokens`

## Todos

- [x] I have added a description to this pull request that describes the changes in detail
- [x] I have performed a self-review of my code
- [x] I have added a label that describes the PR type (`bug`, `enhancement`, `ci`, `refactor`, `documentation`, `test`, `chore`)
- [x] I have updated the _optional_ PR title to follow the pattern `Fix / TICKET_ID / DESCRIPTION` (e.g. `Fix / 123456 / Fixing the login button`)
- [x] I have run manual tests to check if everything is functional
- [ ] I have added screenshots/videos that explain my graphical changes

## Screenshots
