### PR TITLE
fix / 000 / release drafter permissions

### DIFF
--- a/.github/workflows/draft-next-release.yml
+++ b/.github/workflows/draft-next-release.yml
@@ -5,15 +5,12 @@
 
 name: ✍️ Release Drafter
 
-permissions:
-  contents: write
-
 on:
   push:
     branches:
       - main
     paths:
-      - '.github/workflows/release-drafter.yml'
+      - '.github/workflows/draft-release.yml'
       - 'testing/**'
       - 'theme/**'
   workflow_dispatch: {}
@@ -26,16 +23,12 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: ./.github/actions/setup
-
       - uses: release-drafter/release-drafter@65c5fb495d1e69aa8c08a3317bc44ff8aabe9772
         id: releaseDrafter
         with:
           config-name: configs/draft-release.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_DRAFTER_TOKEN }}
 
       # Run version bumping on the theme package
       - run: pnpm version ${{ steps.releaseDrafter.outputs.resolved_version }} --git-tag-version=false --allow-same-version

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -1,5 +1,5 @@
 # Action to label pull requests based on the pre commit config that can be found here:
-# 🪛 https://github.com/hivemq-cloud/hivemq-cloud/blob/develop/.pre-commit-config.yaml
+# 🪛 https://github.com/hivemq/ui-theme/blob/main/.pre-commit-config.yaml
 # ---
 # This action is a prerequisite to allow us to use release-drafter
 # https://github.com/release-drafter/release-drafter


### PR DESCRIPTION
## Why

Release Drafter cannot update the version in package.json and push to main

## What

- simplify draft-next-release.yml
- use a Personal Access Token called GH_RELEASE_DRAFTER_TOKEN with repo and workflow permissions

## Todos

- [x] I have added a description to this pull request that describes the changes in detail
- [x] I have performed a self-review of my code
- [x] I have added a label that describes the PR type (`bug`, `enhancement`, `ci`, `refactor`, `documentation`, `test`, `chore`)
- [x] I have updated the _optional_ PR title to follow the pattern `Fix / TICKET_ID / DESCRIPTION` (e.g. `Fix / 123456 / Fixing the login button`)
- [ ] I have run manual tests to check if everything is functional
- [ ] I have added screenshots/videos that explain my graphical changes

## Screenshots
