### PR TITLE
feat: expand semantic tokens and add theme-lint enhancements

### DIFF
--- a/testing/tsconfig.json
+++ b/testing/tsconfig.json
@@ -17,6 +17,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    "types": ["@testing-library/jest-dom"],
     "baseUrl": ".",
     "paths": {
       "~/*": ["src/*"]

--- a/theme/bin/theme-lint.js
+++ b/theme/bin/theme-lint.js
@@ -72,6 +72,7 @@ function findTsxFiles(dir) {
 }
 
 const IGNORE_COMMENT = 'hivemq-theme-lint-ignore'
+const DISABLE_COMMENT = 'hivemq-theme-lint-disable'
 
 const RULES = [
   {
@@ -109,6 +110,11 @@ const STRICT_RULES = [
 
 function checkFile(filePath, flags) {
   const content = fs.readFileSync(filePath, 'utf8')
+
+  if (content.includes(DISABLE_COMMENT)) {
+    return []
+  }
+
   const lines = content.split('\n')
   const violations = []
   const activeRules = flags.strict ? [...RULES, ...STRICT_RULES] : RULES

--- a/theme/src/__tests__/theme-lint.test.ts
+++ b/theme/src/__tests__/theme-lint.test.ts
@@ -102,6 +102,15 @@ describe('hardcoded-hex rule', () => {
     expect(exitCode).toBe(0)
     expect(stdout).toContain('No theme violations found')
   })
+
+  it('skips entire file with hivemq-theme-lint-disable comment', () => {
+    const dir = createTempTsx(
+      '// hivemq-theme-lint-disable\n<Box color="#DE2C32" bg="rgb(0,0,0)">text</Box>',
+    )
+    const { stdout, exitCode } = runCli([dir])
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('No theme violations found')
+  })
 })
 
 describe('hardcoded-rgb rule', () => {

--- a/theme/src/colors/semantic-tokens.ts
+++ b/theme/src/colors/semantic-tokens.ts
@@ -23,21 +23,18 @@ export const semanticTokens = {
     inverted: { value: { base: '{colors.gray.800}', _dark: '{colors.gray.100}' } },
     muted: { value: { base: '{colors.black.200}', _dark: '{colors.white.200}' } },
   },
-
   /**
    * Text tokens
    */
   text: {
     default: { value: { base: '{colors.gray.900}', _dark: '{colors.gray.50}' } },
   },
-
   /**
    * Border tokens
    */
   border: {
     default: { value: { base: '{colors.gray.900}', _dark: '{colors.gray.50}' } },
   },
-
   /**
    * Tier 2: Content tokens (text and foreground elements)
    */
@@ -53,20 +50,6 @@ export const semanticTokens = {
     info: { value: { base: '{colors.blue.600}', _dark: '{colors.blue.400}' } },
     brand: { value: { base: '{colors.yellow.600}', _dark: '{colors.yellow.300}' } },
     solid: { value: { base: '{colors.gray.200}', _dark: '{colors.gray.800}' } },
-  },
-
-  /**
-   * Shell tokens (UI shell and layout components)
-   * @deprecated Shell tokens shouldn't exist in the new theming system. Guidance will be added later on what to use instead.
-   */
-  shell: {
-    bg: { value: { base: '{colors.gray.50}', _dark: '{colors.gray.900}' } },
-    muted: { value: { base: '{colors.gray.100}', _dark: '{colors.gray.800}' } },
-    subtle: { value: { base: '{colors.gray.200}', _dark: '{colors.gray.700}' } },
-    contrastBg: { value: { base: '{colors.white}', _dark: '{colors.black}' } },
-    border: { value: { base: '{colors.gray.300}', _dark: '{colors.gray.700}' } },
-    group: { value: { base: '{colors.gray.500}', _dark: '{colors.gray.500}' } },
-    item: { value: { base: '{colors.gray.900}', _dark: '{colors.gray.50}' } },
   },
 
   secondary: {
@@ -127,6 +110,15 @@ export const semanticTokens = {
     solid: { value: { base: '{colors.blue.500}', _dark: '{colors.blue.500}' } },
     focusRing: { value: { base: '{colors.blue.400}', _dark: '{colors.blue.400}' } },
   },
+  highlight: {
+    contrast: { value: { base: '{colors.white}', _dark: '{colors.white}' } },
+    fg: { value: { base: '{colors.purple.600}', _dark: '{colors.purple.400}' } },
+    subtle: { value: { base: '{colors.purple.100}', _dark: '{colors.purple.900}' } },
+    muted: { value: { base: '{colors.purple.200}', _dark: '{colors.purple.800}' } },
+    emphasized: { value: { base: '{colors.purple.300}', _dark: '{colors.purple.700}' } },
+    solid: { value: { base: '{colors.purple.500}', _dark: '{colors.purple.500}' } },
+    focusRing: { value: { base: '{colors.purple.400}', _dark: '{colors.purple.400}' } },
+  },
   /**
    * Chart tokens (for libraries like Recharts that need raw CSS values)
    * Resolve via useToken('colors', ['chart.primary']) to pass to chart props.
@@ -136,14 +128,17 @@ export const semanticTokens = {
     selected: { value: { base: '{colors.yellow.400}', _dark: '{colors.yellow.500}' } },
     grid: { value: { base: '{colors.gray.300}', _dark: '{colors.gray.600}' } },
   },
-
-  highlight: {
-    contrast: { value: { base: '{colors.white}', _dark: '{colors.white}' } },
-    fg: { value: { base: '{colors.purple.600}', _dark: '{colors.purple.400}' } },
-    subtle: { value: { base: '{colors.purple.100}', _dark: '{colors.purple.900}' } },
-    muted: { value: { base: '{colors.purple.200}', _dark: '{colors.purple.800}' } },
-    emphasized: { value: { base: '{colors.purple.300}', _dark: '{colors.purple.700}' } },
-    solid: { value: { base: '{colors.purple.500}', _dark: '{colors.purple.500}' } },
-    focusRing: { value: { base: '{colors.purple.400}', _dark: '{colors.purple.400}' } },
+  /**
+   * Shell tokens (UI shell and layout components)
+   * @deprecated Shell tokens shouldn't exist in the new theming system. Guidance will be added later on what to use instead.
+   */
+  shell: {
+    bg: { value: { base: '{colors.gray.50}', _dark: '{colors.gray.900}' } },
+    muted: { value: { base: '{colors.gray.100}', _dark: '{colors.gray.800}' } },
+    subtle: { value: { base: '{colors.gray.200}', _dark: '{colors.gray.700}' } },
+    contrastBg: { value: { base: '{colors.white}', _dark: '{colors.black}' } },
+    border: { value: { base: '{colors.gray.300}', _dark: '{colors.gray.700}' } },
+    group: { value: { base: '{colors.gray.500}', _dark: '{colors.gray.500}' } },
+    item: { value: { base: '{colors.gray.900}', _dark: '{colors.gray.50}' } },
   },
 }

--- a/theme/src/colors/semantic-tokens.ts
+++ b/theme/src/colors/semantic-tokens.ts
@@ -19,21 +19,23 @@ export const semanticTokens = {
    * Background tokens
    */
   bg: {
-    DEFAULT: { value: { base: '{colors.gray.50}', _dark: '{colors.gray.950}' } },
+    default: { value: { base: '{colors.gray.50}', _dark: '{colors.gray.950}' } },
+    inverted: { value: { base: '{colors.gray.800}', _dark: '{colors.gray.100}' } },
+    muted: { value: { base: '{colors.black.200}', _dark: '{colors.white.200}' } },
   },
 
   /**
    * Text tokens
    */
   text: {
-    DEFAULT: { value: { base: '{colors.gray.900}', _dark: '{colors.gray.50}' } },
+    default: { value: { base: '{colors.gray.900}', _dark: '{colors.gray.50}' } },
   },
 
   /**
    * Border tokens
    */
   border: {
-    DEFAULT: { value: { base: '{colors.gray.900}', _dark: '{colors.gray.50}' } },
+    default: { value: { base: '{colors.gray.900}', _dark: '{colors.gray.50}' } },
   },
 
   /**
@@ -88,6 +90,7 @@ export const semanticTokens = {
   success: {
     contrast: { value: { base: '{colors.white}', _dark: '{colors.white}' } },
     fg: { value: { base: '{colors.green.600}', _dark: '{colors.green.400}' } },
+    faint: { value: { base: '{colors.green.50}', _dark: '{colors.green.950}' } },
     subtle: { value: { base: '{colors.green.100}', _dark: '{colors.green.900}' } },
     muted: { value: { base: '{colors.green.200}', _dark: '{colors.green.800}' } },
     emphasized: { value: { base: '{colors.green.300}', _dark: '{colors.green.700}' } },
@@ -97,6 +100,7 @@ export const semanticTokens = {
   danger: {
     contrast: { value: { base: '{colors.white}', _dark: '{colors.white}' } },
     fg: { value: { base: '{colors.red.700}', _dark: '{colors.red.400}' } },
+    faint: { value: { base: '{colors.red.50}', _dark: '{colors.red.950}' } },
     subtle: { value: { base: '{colors.red.100}', _dark: '{colors.red.900}' } },
     muted: { value: { base: '{colors.red.300}', _dark: '{colors.red.800}' } },
     emphasized: { value: { base: '{colors.red.400}', _dark: '{colors.red.700}' } },
@@ -106,6 +110,7 @@ export const semanticTokens = {
   warning: {
     contrast: { value: { base: '{colors.white}', _dark: '{colors.white}' } },
     fg: { value: { base: '{colors.orange.700}', _dark: '{colors.orange.400}' } },
+    faint: { value: { base: '{colors.orange.50}', _dark: '{colors.orange.950}' } },
     subtle: { value: { base: '{colors.orange.100}', _dark: '{colors.orange.900}' } },
     muted: { value: { base: '{colors.orange.300}', _dark: '{colors.orange.800}' } },
     emphasized: { value: { base: '{colors.orange.400}', _dark: '{colors.orange.700}' } },
@@ -115,12 +120,23 @@ export const semanticTokens = {
   info: {
     contrast: { value: { base: '{colors.white}', _dark: '{colors.white}' } },
     fg: { value: { base: '{colors.blue.600}', _dark: '{colors.blue.400}' } },
+    faint: { value: { base: '{colors.blue.50}', _dark: '{colors.blue.950}' } },
     subtle: { value: { base: '{colors.blue.100}', _dark: '{colors.blue.900}' } },
     muted: { value: { base: '{colors.blue.200}', _dark: '{colors.blue.800}' } },
     emphasized: { value: { base: '{colors.blue.300}', _dark: '{colors.blue.700}' } },
     solid: { value: { base: '{colors.blue.500}', _dark: '{colors.blue.500}' } },
     focusRing: { value: { base: '{colors.blue.400}', _dark: '{colors.blue.400}' } },
   },
+  /**
+   * Chart tokens (for libraries like Recharts that need raw CSS values)
+   * Resolve via useToken('colors', ['chart.primary']) to pass to chart props.
+   */
+  chart: {
+    primary: { value: { base: '{colors.blue.500}', _dark: '{colors.blue.400}' } },
+    selected: { value: { base: '{colors.yellow.400}', _dark: '{colors.yellow.500}' } },
+    grid: { value: { base: '{colors.gray.300}', _dark: '{colors.gray.600}' } },
+  },
+
   highlight: {
     contrast: { value: { base: '{colors.white}', _dark: '{colors.white}' } },
     fg: { value: { base: '{colors.purple.600}', _dark: '{colors.purple.400}' } },

--- a/theme/src/colors/semantic-tokens.ts
+++ b/theme/src/colors/semantic-tokens.ts
@@ -113,6 +113,7 @@ export const semanticTokens = {
   highlight: {
     contrast: { value: { base: '{colors.white}', _dark: '{colors.white}' } },
     fg: { value: { base: '{colors.purple.600}', _dark: '{colors.purple.400}' } },
+    faint: { value: { base: '{colors.purple.50}', _dark: '{colors.purple.950}' } },
     subtle: { value: { base: '{colors.purple.100}', _dark: '{colors.purple.900}' } },
     muted: { value: { base: '{colors.purple.200}', _dark: '{colors.purple.800}' } },
     emphasized: { value: { base: '{colors.purple.300}', _dark: '{colors.purple.700}' } },


### PR DESCRIPTION
## Summary

- Add new semantic background tokens: `bg.inverted` (dark surface on light mode) and `bg.muted` (semi-transparent overlay)
- Add `faint` tier to status palettes (`success`, `danger`, `warning`, `info`) for the lightest `.50` shade backgrounds
- Add chart semantic tokens: `chart.primary`, `chart.selected`, `chart.grid` for use with libraries like Recharts via `useToken()`
- Add `// hivemq-theme-lint-disable` file-level comment to skip entire files
- Refactor `DEFAULT` → `default` for bg, text, border tokens
- Move shell tokens (deprecated) to bottom of file

## New Tokens

| Token | Light | Dark | Purpose |
|-------|-------|------|---------|
| `bg.inverted` | gray.800 | gray.100 | Dark surfaces (tooltips, popovers) |
| `bg.muted` | black 8% | white 8% | Semi-transparent overlays |
| `success.faint` | green.50 | green.950 | Lightest success background |
| `danger.faint` | red.50 | red.950 | Lightest danger background |
| `warning.faint` | orange.50 | orange.950 | Lightest warning background |
| `info.faint` | blue.50 | blue.950 | Lightest info background |
| `chart.primary` | blue.500 | blue.400 | Primary chart line/area |
| `chart.selected` | yellow.400 | yellow.500 | Selected chart element |
| `chart.grid` | gray.300 | gray.600 | Chart grid/cursor lines |


## Outcome for CCv2

With these additions i can get CCv2 down to only some mentions of hardcoded monospace fonts which are basically false positives.

```
theme-lint: src/components/toolbar/SettingsToolbar.tsx
  line 107: hardcoded-font — Found hardcoded font-family, use fontFamily="heading|body|monospace" token instead

theme-lint: src/modules/backup/pages/BackupPage.tsx
  line 400: hardcoded-font — Found hardcoded font-family, use fontFamily="heading|body|monospace" token instead

theme-lint: src/modules/clients/components/details/ClientDetailSessionInformation.tsx
  line 195: hardcoded-font — Found hardcoded font-family, use fontFamily="heading|body|monospace" token instead
  line 481: hardcoded-font — Found hardcoded font-family, use fontFamily="heading|body|monospace" token instead

theme-lint: src/modules/clients/components/details/modals/CertificateDetailsModal.tsx
  line 73: hardcoded-font — Found hardcoded font-family, use fontFamily="heading|body|monospace" token instead
  line 95: hardcoded-font — Found hardcoded font-family, use fontFamily="heading|body|monospace" token instead
  line 100: hardcoded-font — Found hardcoded font-family, use fontFamily="heading|body|monospace" token instead

theme-lint: src/modules/dashboard/components/atoms/NodeName.tsx
  line 25: hardcoded-font — Found hardcoded font-family, use fontFamily="heading|body|monospace" token instead

theme-lint: src/modules/dashboard/components/molecule/NodesTable.tsx
  line 175: hardcoded-font — Found hardcoded font-family, use fontFamily="heading|body|monospace" token instead
  line 176: hardcoded-font — Found hardcoded font-family, use fontFamily="heading|body|monospace" token instead
  line 380: hardcoded-font — Found hardcoded font-family, use fontFamily="heading|body|monospace" token instead
  line 383: hardcoded-font — Found hardcoded font-family, use fontFamily="heading|body|monospace" token instead

12 violations found in 6 files
```